### PR TITLE
Add Park UI theme config and missing dependency for panda as describe…

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
   },
   "dependencies": {
     "@ark-ui/react": "0.15.0",
+    "@park-ui/panda-preset": "^0.25.0",
     "@park-ui/presets": "0.16.0",
     "next": "^14.0.3",
     "react": "^18.2.0",

--- a/panda.config.ts
+++ b/panda.config.ts
@@ -1,18 +1,43 @@
-import { defineConfig } from '@pandacss/dev'
-import {badgeRecipe} from "./badgeRecipe"
+import {defineConfig} from '@pandacss/dev'
+import {createPreset} from '@park-ui/panda-preset'
+import {badgeRecipe} from './badgeRecipe'
 
 export default defineConfig({
-  preflight: true,
-  presets: ['@pandacss/dev/presets', '@park-ui/presets'],
-  include: ['./src/**/*.{js,jsx,ts,tsx}', './pages/**/*.{js,jsx,ts,tsx}'],
-  exclude: [],
-  theme: {
-    extend: {
-      recipes: {
-        badge: badgeRecipe
-      }
+    preflight: true,
+    presets: [
+        '@pandacss/preset-base',
+        createPreset({
+            accentColor: 'grass',
+            grayColor: 'mauve',
+            borderRadius: 'md',
+        }),
+    ],
+    include: ['./src/**/*.{js,jsx,ts,tsx}', './pages/**/*.{js,jsx,ts,tsx}'],
+    exclude: [],
+    theme: {
+        extend: {
+            recipes: {
+                badge: badgeRecipe,
+            },
+        },
     },
-  },
-  jsxFramework: 'react',
-  outdir: 'styled-system',
+    jsxFramework: 'react',
+    outdir: 'styled-system',
 })
+
+// import {defineConfig} from '@pandacss/dev'
+
+// export default defineConfig({
+//     preflight: true,
+//     presets: [
+//         '@pandacss/preset-base',
+//         createPreset({
+//             accentColor: 'grass',
+//             grayColor: 'mauve',
+//             borderRadius: 'md',
+//         }),
+//     ],
+//     include: ['./src/**/*.{js,jsx,ts,tsx}'],
+//     jsxFramework: 'react',
+//     outdir: 'styled-system',
+// })

--- a/panda.config.ts
+++ b/panda.config.ts
@@ -24,20 +24,3 @@ export default defineConfig({
     jsxFramework: 'react',
     outdir: 'styled-system',
 })
-
-// import {defineConfig} from '@pandacss/dev'
-
-// export default defineConfig({
-//     preflight: true,
-//     presets: [
-//         '@pandacss/preset-base',
-//         createPreset({
-//             accentColor: 'grass',
-//             grayColor: 'mauve',
-//             borderRadius: 'md',
-//         }),
-//     ],
-//     include: ['./src/**/*.{js,jsx,ts,tsx}'],
-//     jsxFramework: 'react',
-//     outdir: 'styled-system',
-// })

--- a/src/components/card.tsx
+++ b/src/components/card.tsx
@@ -1,48 +1,52 @@
 // 'use client'
 
-import { Pill } from '../components/pill'
-import { cva, css } from '../../styled-system/css'
-import { styled } from '../../styled-system/jsx'
-import { Badge } from '~/components/ui/badge'
+import {Pill} from '../components/pill'
+import {cva, css} from '../../styled-system/css'
+import {styled} from '../../styled-system/jsx'
+import {Badge} from '~/components/ui/badge'
+import {Button} from '~/components/ui/button'
 
 type propType = {
-	heading: string
-	eventDate: Date
-	desc?: string
-	categories?: string[]
+    heading: string
+    eventDate: Date
+    desc?: string
+    categories?: string[]
 }
 
 const cardStyle = cva({
-	base: {
-		padding: '0.75em',
-		borderRadius: 'sm',
-		border: '2px solid gray',
-		width: '100%',
-		display: 'flex',
-		flexFlow: 'column',
-		gap: '1rem',
-	},
+    base: {
+        padding: '0.75em',
+        borderRadius: 'sm',
+        border: '2px solid gray',
+        width: '100%',
+        display: 'flex',
+        flexFlow: 'column',
+        gap: '1rem',
+    },
 })
 
 const CardBox = styled('div', cardStyle)
 
 export const Card = (props: propType) => (
-	<CardBox>
-		<h2>{props.heading}</h2>
-		<p>
-			{new Date(props.eventDate).toLocaleString(undefined, {
-				year: 'numeric',
-				month: 'long',
-				day: 'numeric',
-			})}
-		</p>
-		{<p>Description: {props.desc ? props.desc : ''}</p>}
-		{props.categories && (
-			<p>
-				{props.categories.map((category) => (
-					<Badge key={category}>{category}</Badge>
-				))}
-			</p>
-		)}
-	</CardBox>
+    <CardBox>
+        <h2>{props.heading}</h2>
+        <p>
+            {new Date(props.eventDate).toLocaleString(undefined, {
+                year: 'numeric',
+                month: 'long',
+                day: 'numeric',
+            })}
+        </p>
+        {<p>Description: {props.desc ? props.desc : ''}</p>}
+        {props.categories && (
+            <>
+                <p>
+                    {props.categories.map((category) => (
+                        <Badge key={category}>{category}</Badge>
+                    ))}
+                </p>
+                <Button>Add to Calendar</Button>
+            </>
+        )}
+    </CardBox>
 )


### PR DESCRIPTION
Add Park UI theme config and missing dependency for panda as described in park-ui.com >> "copy config" >> "make it yours"

Go ahead and merge this PR @3dvkr if you test it and everything looks good and it's not stepping on the toes of what you're working on

<img width="587" alt="image" src="https://github.com/meetnearme/frontend/assets/806536/5edbd55b-b158-4c24-8f1c-4b1985426dd1">

## Minor UI change to show the theme

<img width="1023" alt="image" src="https://github.com/meetnearme/frontend/assets/806536/84bb62f8-fe2e-421f-8eca-7a9d3ebd961c">
